### PR TITLE
Fix missing button handlers

### DIFF
--- a/test.html
+++ b/test.html
@@ -385,7 +385,7 @@
 <h3>Экспорт данных</h3>
 
     <button class="btn btn-primary" onclick="onExportJson()">Выгрузить JSON</button>
-    <button class="btn btn-info" id="downloadJsonFileBtn" onclick="downloadJsonFile()">Скачать JSON файл</button>
+    <button class="btn btn-info" id="downloadJsonFileBtn">Скачать JSON файл</button>
     <button class="btn btn-secondary" onclick="onExportHistory()">Выгрузить историю</button>
     <textarea id="exportArea" class="form-control mt-2" rows="5"></textarea>
 
@@ -3292,9 +3292,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.getElementById('savePrinterJsonBtn').onclick = savePrinterJson;
   document.getElementById('importPrinterJsonBtn').onclick = ()=>document.getElementById('orcaPrinterJsonFile').click();
   document.getElementById('orcaPrinterJsonFile').addEventListener('change',e=>importPrinterJson(e.target.files[0]));
+  document.getElementById('downloadOrcaJsonBtn').onclick = downloadOrcaJson;
+  document.getElementById('downloadPrinterJsonBtn').onclick = downloadPrinterJson;
+  document.getElementById('saveMaterialBtn').onclick = saveMaterialFromModal;
+  document.getElementById('savePrinterBtn').onclick = savePrinterFromModal;
   document.getElementById('downloadJsonFileBtn')?.addEventListener('click', downloadJsonFile);
   document.getElementById('importJsonFile').addEventListener('change', importFromFile);
-  
+
   document.getElementById('downloadOrcaInfoBtn').onclick = downloadOrcaInfo;
   document.getElementById('downloadPrinterInfoBtn').onclick = downloadPrinterInfo;
   // document.getElementById('orcaPrinterFileInput').addEventListener('change',(e)=>{


### PR DESCRIPTION
## Summary
- hook up OrcaSlicer JSON/Printer JSON download buttons
- connect Save buttons for printer and material modals
- drop redundant onclick on JSON download

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850dfaf38e8833085349defd6c91a62