### PR TITLE
Fix ID string comparisons in test.html

### DIFF
--- a/test.html
+++ b/test.html
@@ -975,7 +975,7 @@ function massDelete(type) {
     case 'printerAdditional':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           printer.additional = printer.additional.filter(a => {
             const chk = document.getElementById("chk_printerAdditional_"+a.id);
@@ -988,7 +988,7 @@ function massDelete(type) {
     case 'printerMaterials':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           printer.materials = printer.materials.filter(m => {
             const chk = document.getElementById("chk_printerMaterials_"+m.id);
@@ -1074,7 +1074,7 @@ async function massEdit(type) {
     case 'printerAdditional':
       {
         const printerId=getCurrentPrinterId();
-        const printer=appData.printers.find(p=>p.id===printerId);
+        const printer=appData.printers.find(p=>String(p.id)===String(printerId));
         if(printer){
           const vals=await showMultiPrompt('Расходы принтера',[
             {id:'cost',label:'Стоимость (₽)',type:'number'},
@@ -1097,7 +1097,7 @@ async function massEdit(type) {
     case 'printerMaterials':
       {
         const printerId=getCurrentPrinterId();
-        const printer=appData.printers.find(p=>p.id===printerId);
+        const printer=appData.printers.find(p=>String(p.id)===String(printerId));
         if(printer){
           const vals=await showMultiPrompt('Материалы принтера',[
             {id:'cost',label:'Стоимость за кг',type:'number'},
@@ -1142,7 +1142,7 @@ function copyElement(type, id) {
       break;
     case 'globalMaterials':
       {
-        const orig = appData.materials.find(m => m.id === id);
+        const orig = appData.materials.find(m => String(m.id) === String(id));
         if(orig){
           const copy = JSON.parse(JSON.stringify(orig));
           copy.id = generateUUID();
@@ -1167,7 +1167,7 @@ function copyElement(type, id) {
     case 'printerAdditional':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           const orig = printer.additional.find(a => a.id == id);
           if(orig){
@@ -1183,7 +1183,7 @@ function copyElement(type, id) {
     case 'printerMaterials':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           const orig = printer.materials.find(m => m.id == id);
           if(orig){
@@ -1272,7 +1272,7 @@ function savePrinterFromModal(){
 }
 function onDeletePrinter(id){
   if(!confirm("Удалить принтер?")) return;
-  appData.printers = appData.printers.filter(x => x.id !== id);
+  appData.printers = appData.printers.filter(x => String(x.id) !== String(id));
   saveToLocalStorage();
   renderPrintersTable();
   document.getElementById("printerDetails").style.display = "none";
@@ -1339,7 +1339,7 @@ function onShowPrinterDetails(id){
   document.getElementById("btnAddPrinterMaterial").onclick = () => onAddPrinterMaterial(printer.id);
 }
 function onAddPrinterAdditional(printerId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   const nid = generateUUID();
   pr.additional.push({
@@ -1353,7 +1353,7 @@ function onAddPrinterAdditional(printerId){
   onShowPrinterDetails(printerId);
 }
 async function onEditPrinterAdditional(printerId, addId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   const it = pr.additional.find(a => a.id === addId);
   if(!it) return;
@@ -1372,15 +1372,15 @@ async function onEditPrinterAdditional(printerId, addId){
   onShowPrinterDetails(printerId);
 }
 function onDeletePrinterAdditional(printerId, addId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   if(!confirm("Удалить статью?")) return;
-  pr.additional = pr.additional.filter(a => a.id !== addId);
+  pr.additional = pr.additional.filter(a => String(a.id) !== String(addId));
   saveToLocalStorage();
   onShowPrinterDetails(printerId);
 }
 function onAddPrinterMaterial(printerId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   const nid = generateUUID();
   pr.materials.push({
@@ -1398,9 +1398,9 @@ function onAddPrinterMaterial(printerId){
   onShowPrinterDetails(printerId);
 }
 async function onEditPrinterMaterial(printerId, matId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
-  const mat = pr.materials.find(m => m.id === matId);
+  const mat = pr.materials.find(m => String(m.id) === String(matId));
   if(!mat) return;
   const vals = await showMultiPrompt('Материал принтера',[
     {id:'name',label:'Название',value:mat.name},
@@ -1423,10 +1423,10 @@ async function onEditPrinterMaterial(printerId, matId){
   onShowPrinterDetails(printerId);
 }
 function onDeletePrinterMaterial(printerId, matId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   if(!confirm("Удалить материал?")) return;
-  pr.materials = pr.materials.filter(m => m.id !== matId);
+  pr.materials = pr.materials.filter(m => String(m.id) !== String(matId));
   saveToLocalStorage();
   onShowPrinterDetails(printerId);
 }
@@ -1509,7 +1509,7 @@ function saveMaterialFromModal(){
 }
 function onDeleteGlobalMaterial(id){
   if(!confirm("Удалить материал?")) return;
-  appData.materials = appData.materials.filter(x => x.id !== id);
+  appData.materials = appData.materials.filter(x => String(x.id) !== String(id));
   saveToLocalStorage();
   renderGlobalMaterialsTable();
 }
@@ -1572,7 +1572,7 @@ async function onEditGlobalAdditional(id){
 }
 function onDeleteGlobalAdditional(id){
   if(!confirm("Удалить статью?")) return;
-  appData.additionalGlobal = appData.additionalGlobal.filter(a => a.id !== id);
+  appData.additionalGlobal = appData.additionalGlobal.filter(a => String(a.id) !== String(id));
   saveToLocalStorage();
   renderGlobalAdditionalTable();
 }
@@ -1730,7 +1730,7 @@ function addModelRow(printerId, modelData) {
   tbody.appendChild(tr);
 }
 function getAllMaterialsForPrinter(printerId, includeAll=false){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return [];
   const globalMats = appData.materials.filter(m => {
     if(!includeAll && m.balance <= 0) return false;
@@ -1841,7 +1841,7 @@ function onCalculateAll() {
       
       prTime += h;
       
-      const mat = getAllMaterialsForPrinter(pr.id).find(x => x.id === mid);
+      const mat = getAllMaterialsForPrinter(pr.id).find(x => String(x.id) === String(mid));
       if (!mat) return;
       
       const costPH = (pr.hoursToRecoup > 0) ? pr.cost / pr.hoursToRecoup : 0;
@@ -2440,11 +2440,11 @@ function downloadThermoLabelHtml(modelName, printerName, materialName, hours, we
 /* Новая функция для генерации этикетки материала в формате 30x20 мм */
 function downloadMaterialLabelHtml(materialId) {
   // Ищем материал сначала в глобальных, затем в материалах принтеров
-  let mat = appData.materials.find(m => m.id === materialId);
+  let mat = appData.materials.find(m => String(m.id) === String(materialId));
   if(!mat) {
     // Если не найден в глобальных, проверяем у каждого принтера
     for(let p of appData.printers) {
-      mat = p.materials.find(m => m.id === materialId);
+      mat = p.materials.find(m => String(m.id) === String(materialId));
       if(mat) break;
     }
   }


### PR DESCRIPTION
## Summary
- ensure printer and material IDs are compared using string coercion
- keep dropdowns populated when editing history and fix printer detail calculations

## Testing
- `git diff --color --stat`


------
https://chatgpt.com/codex/tasks/task_e_6850f4d7cf188330b417c7a80748fcdb