### PR TITLE
Fix printer details lookup

### DIFF
--- a/test.html
+++ b/test.html
@@ -975,7 +975,7 @@ function massDelete(type) {
     case 'printerAdditional':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           printer.additional = printer.additional.filter(a => {
             const chk = document.getElementById("chk_printerAdditional_"+a.id);
@@ -988,7 +988,7 @@ function massDelete(type) {
     case 'printerMaterials':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
           printer.materials = printer.materials.filter(m => {
             const chk = document.getElementById("chk_printerMaterials_"+m.id);
@@ -1074,7 +1074,7 @@ async function massEdit(type) {
     case 'printerAdditional':
       {
         const printerId=getCurrentPrinterId();
-        const printer=appData.printers.find(p=>p.id===printerId);
+        const printer=appData.printers.find(p=>String(p.id)===String(printerId));
         if(printer){
           const vals=await showMultiPrompt('Расходы принтера',[
             {id:'cost',label:'Стоимость (₽)',type:'number'},
@@ -1097,7 +1097,7 @@ async function massEdit(type) {
     case 'printerMaterials':
       {
         const printerId=getCurrentPrinterId();
-        const printer=appData.printers.find(p=>p.id===printerId);
+        const printer=appData.printers.find(p=>String(p.id)===String(printerId));
         if(printer){
           const vals=await showMultiPrompt('Материалы принтера',[
             {id:'cost',label:'Стоимость за кг',type:'number'},
@@ -1130,7 +1130,7 @@ function copyElement(type, id) {
   switch(type) {
     case 'printers':
       {
-        const orig = appData.printers.find(p => p.id === id);
+        const orig = appData.printers.find(p => String(p.id) === String(id));
         if(orig){
           const copy = JSON.parse(JSON.stringify(orig));
           copy.id = generateUUID();
@@ -1142,7 +1142,7 @@ function copyElement(type, id) {
       break;
     case 'globalMaterials':
       {
-        const orig = appData.materials.find(m => m.id === id);
+        const orig = appData.materials.find(m => String(m.id) === String(id));
         if(orig){
           const copy = JSON.parse(JSON.stringify(orig));
           copy.id = generateUUID();
@@ -1154,7 +1154,7 @@ function copyElement(type, id) {
       break;
     case 'globalAdditional':
       {
-        const orig = appData.additionalGlobal.find(a => a.id === id);
+        const orig = appData.additionalGlobal.find(a => String(a.id) === String(id));
         if(orig){
           const copy = JSON.parse(JSON.stringify(orig));
           copy.id = generateUUID();
@@ -1167,9 +1167,9 @@ function copyElement(type, id) {
     case 'printerAdditional':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
-          const orig = printer.additional.find(a => a.id == id);
+          const orig = printer.additional.find(a => String(a.id) === String(id));
           if(orig){
             const copy = JSON.parse(JSON.stringify(orig));
             copy.id = generateUUID();
@@ -1183,9 +1183,9 @@ function copyElement(type, id) {
     case 'printerMaterials':
       {
         const printerId = getCurrentPrinterId();
-        const printer = appData.printers.find(p => p.id === printerId);
+        const printer = appData.printers.find(p => String(p.id) === String(printerId));
         if(printer){
-          const orig = printer.materials.find(m => m.id == id);
+          const orig = printer.materials.find(m => String(m.id) === String(id));
           if(orig){
             const copy = JSON.parse(JSON.stringify(orig));
             copy.id = generateUUID();
@@ -1219,11 +1219,11 @@ function renderPrintersTable(){
       <td>${printer.maintCostHour}<\/td>
       <td>
         <div class="btn-group-sm">
-          <button class="btn btn-secondary" onclick="onEditPrinter(${printer.id})">Ред.<\/button>
-          <button class="btn btn-success" onclick="openPrinterOrca(${printer.id})">Orca<\/button>
-          <button class="btn btn-info" onclick="onShowPrinterDetails(${printer.id})">Детали<\/button>
-          <button class="btn btn-warning" onclick="copyElement('printers', ${printer.id})">Копировать<\/button>
-          <button class="btn btn-danger" onclick="onDeletePrinter(${printer.id})">Удл.<\/button>
+          <button class="btn btn-secondary" onclick="onEditPrinter('${printer.id}')">Ред.<\/button>
+          <button class="btn btn-success" onclick="openPrinterOrca('${printer.id}')">Orca<\/button>
+          <button class="btn btn-info" onclick="onShowPrinterDetails('${printer.id}')">Детали<\/button>
+          <button class="btn btn-warning" onclick="copyElement('printers', '${printer.id}')">Копировать<\/button>
+          <button class="btn btn-danger" onclick="onDeletePrinter('${printer.id}')">Удл.<\/button>
         <\/div>
       <\/td>
     `;
@@ -1248,7 +1248,7 @@ function onAddPrinter(){
 }
 let currentPrinterEditId = null;
 function onEditPrinter(id){
-  const p = appData.printers.find(x => x.id === id);
+  const p = appData.printers.find(x => String(x.id) === String(id));
   if(!p) return;
   currentPrinterEditId = id;
   document.getElementById('printerNameInput').value = p.name;
@@ -1259,7 +1259,7 @@ function onEditPrinter(id){
   new bootstrap.Modal(document.getElementById('printerModal')).show();
 }
 function savePrinterFromModal(){
-  const p = appData.printers.find(x => x.id === currentPrinterEditId);
+  const p = appData.printers.find(x => String(x.id) === String(currentPrinterEditId));
   if(!p) return;
   p.name = document.getElementById('printerNameInput').value;
   p.cost = parseFloat(document.getElementById('printerCostInput').value) || 0;
@@ -1272,13 +1272,13 @@ function savePrinterFromModal(){
 }
 function onDeletePrinter(id){
   if(!confirm("Удалить принтер?")) return;
-  appData.printers = appData.printers.filter(x => x.id !== id);
+  appData.printers = appData.printers.filter(x => String(x.id) !== String(id));
   saveToLocalStorage();
   renderPrintersTable();
   document.getElementById("printerDetails").style.display = "none";
 }
 function onShowPrinterDetails(id){
-  const printer = appData.printers.find(p => p.id === id);
+  const printer = appData.printers.find(p => String(p.id) === String(id));
   if(!printer) return;
   document.getElementById("printerDetails").style.display = "block";
   document.getElementById("printerDetailsName").textContent = printer.name;
@@ -1298,9 +1298,9 @@ function onShowPrinterDetails(id){
       <td>${(a.printers && a.printers.length)? a.printers.map(printerNameById).join(', '): 'Все'}<\/td>
       <td>
         <div class="btn-group-sm">
-          <button class="btn btn-secondary" onclick="onEditPrinterAdditional(${printer.id}, ${a.id})">Ред.<\/button>
-          <button class="btn btn-warning" onclick="copyElement('printerAdditional', ${a.id})">Копировать<\/button>
-          <button class="btn btn-danger" onclick="onDeletePrinterAdditional(${printer.id}, ${a.id})">Удл.<\/button>
+          <button class="btn btn-secondary" onclick="onEditPrinterAdditional('${printer.id}', '${a.id}')">Ред.<\/button>
+          <button class="btn btn-warning" onclick="copyElement('printerAdditional', '${a.id}')">Копировать<\/button>
+          <button class="btn btn-danger" onclick="onDeletePrinterAdditional('${printer.id}', '${a.id}')">Удл.<\/button>
         <\/div>
       <\/td>
     `;
@@ -1324,11 +1324,11 @@ function onShowPrinterDetails(id){
       <td>${(m.printers && m.printers.length) ? m.printers.map(printerNameById).join(', ') : 'Все'}<\/td>
       <td>
         <div class="btn-group-sm">
-          <button class="btn btn-secondary" onclick="onEditPrinterMaterial(${printer.id}, ${m.id})">Ред.<\/button>
-          <button class="btn btn-success" onclick="openOrcaConfig(${m.id})">Orca<\/button>
-          <button class="btn btn-info" onclick="downloadMaterialLabelHtml(${m.id})">Этикетка<\/button>
-          <button class="btn btn-warning" onclick="copyElement('printerMaterials', ${m.id})">Копировать<\/button>
-          <button class="btn btn-danger" onclick="onDeletePrinterMaterial(${printer.id}, ${m.id})">Удл.<\/button>
+          <button class="btn btn-secondary" onclick="onEditPrinterMaterial('${printer.id}', '${m.id}')">Ред.<\/button>
+          <button class="btn btn-success" onclick="openOrcaConfig('${m.id}')">Orca<\/button>
+          <button class="btn btn-info" onclick="downloadMaterialLabelHtml('${m.id}')">Этикетка<\/button>
+          <button class="btn btn-warning" onclick="copyElement('printerMaterials', '${m.id}')">Копировать<\/button>
+          <button class="btn btn-danger" onclick="onDeletePrinterMaterial('${printer.id}', '${m.id}')">Удл.<\/button>
         <\/div>
       <\/td>
     `;
@@ -1339,7 +1339,7 @@ function onShowPrinterDetails(id){
   document.getElementById("btnAddPrinterMaterial").onclick = () => onAddPrinterMaterial(printer.id);
 }
 function onAddPrinterAdditional(printerId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   const nid = generateUUID();
   pr.additional.push({
@@ -1353,9 +1353,9 @@ function onAddPrinterAdditional(printerId){
   onShowPrinterDetails(printerId);
 }
 async function onEditPrinterAdditional(printerId, addId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
-  const it = pr.additional.find(a => a.id === addId);
+  const it = pr.additional.find(a => String(a.id) === String(addId));
   if(!it) return;
   const vals = await showMultiPrompt('Статья принтера',[
     {id:'desc',label:'Описание',value:it.description},
@@ -1372,15 +1372,15 @@ async function onEditPrinterAdditional(printerId, addId){
   onShowPrinterDetails(printerId);
 }
 function onDeletePrinterAdditional(printerId, addId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   if(!confirm("Удалить статью?")) return;
-  pr.additional = pr.additional.filter(a => a.id !== addId);
+  pr.additional = pr.additional.filter(a => String(a.id) !== String(addId));
   saveToLocalStorage();
   onShowPrinterDetails(printerId);
 }
 function onAddPrinterMaterial(printerId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   const nid = generateUUID();
   pr.materials.push({
@@ -1398,9 +1398,9 @@ function onAddPrinterMaterial(printerId){
   onShowPrinterDetails(printerId);
 }
 async function onEditPrinterMaterial(printerId, matId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
-  const mat = pr.materials.find(m => m.id === matId);
+  const mat = pr.materials.find(m => String(m.id) === String(matId));
   if(!mat) return;
   const vals = await showMultiPrompt('Материал принтера',[
     {id:'name',label:'Название',value:mat.name},
@@ -1423,10 +1423,10 @@ async function onEditPrinterMaterial(printerId, matId){
   onShowPrinterDetails(printerId);
 }
 function onDeletePrinterMaterial(printerId, matId){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return;
   if(!confirm("Удалить материал?")) return;
-  pr.materials = pr.materials.filter(m => m.id !== matId);
+  pr.materials = pr.materials.filter(m => String(m.id) !== String(matId));
   saveToLocalStorage();
   onShowPrinterDetails(printerId);
 }
@@ -1449,11 +1449,11 @@ function renderGlobalMaterialsTable(){
       <td>${(m.printers && m.printers.length) ? m.printers.map(printerNameById).join(', ') : 'Все'}<\/td>
       <td>
         <div class="btn-group-sm">
-          <button class="btn btn-secondary" onclick="onEditGlobalMaterial(${m.id})">Ред.<\/button>
-          <button class="btn btn-success" onclick="openOrcaConfig(${m.id})">Orca<\/button>
-          <button class="btn btn-info" onclick="downloadMaterialLabelHtml(${m.id})">Этикетка<\/button>
-          <button class="btn btn-warning" onclick="copyElement('globalMaterials', ${m.id})">Копировать<\/button>
-          <button class="btn btn-danger" onclick="onDeleteGlobalMaterial(${m.id})">Удл.<\/button>
+          <button class="btn btn-secondary" onclick="onEditGlobalMaterial('${m.id}')">Ред.<\/button>
+          <button class="btn btn-success" onclick="openOrcaConfig('${m.id}')">Orca<\/button>
+          <button class="btn btn-info" onclick="downloadMaterialLabelHtml('${m.id}')">Этикетка<\/button>
+          <button class="btn btn-warning" onclick="copyElement('globalMaterials', '${m.id}')">Копировать<\/button>
+          <button class="btn btn-danger" onclick="onDeleteGlobalMaterial('${m.id}')">Удл.<\/button>
         <\/div>
       <\/td>
     `;
@@ -1475,7 +1475,7 @@ function onAddGlobalMaterial(){
   new bootstrap.Modal(document.getElementById('materialModal')).show();
 }
 function onEditGlobalMaterial(id){
-  const m = appData.materials.find(x => x.id === id);
+  const m = appData.materials.find(x => String(x.id) === String(id));
   if(!m) return;
   currentMaterialEditId = id;
   document.getElementById('matNameInput').value = m.name;
@@ -1509,7 +1509,7 @@ function saveMaterialFromModal(){
 }
 function onDeleteGlobalMaterial(id){
   if(!confirm("Удалить материал?")) return;
-  appData.materials = appData.materials.filter(x => x.id !== id);
+  appData.materials = appData.materials.filter(x => String(x.id) !== String(id));
   saveToLocalStorage();
   renderGlobalMaterialsTable();
 }
@@ -1529,9 +1529,9 @@ function renderGlobalAdditionalTable(){
       <td>${(a.printers && a.printers.length)? a.printers.map(printerNameById).join(', '): 'Все'}<\/td>
       <td>
         <div class="btn-group-sm">
-          <button class="btn btn-secondary" onclick="onEditGlobalAdditional(${a.id})">Ред.<\/button>
-          <button class="btn btn-warning" onclick="copyElement('globalAdditional', ${a.id})">Копировать<\/button>
-          <button class="btn btn-danger" onclick="onDeleteGlobalAdditional(${a.id})">Удл.<\/button>
+          <button class="btn btn-secondary" onclick="onEditGlobalAdditional('${a.id}')">Ред.<\/button>
+          <button class="btn btn-warning" onclick="copyElement('globalAdditional', '${a.id}')">Копировать<\/button>
+          <button class="btn btn-danger" onclick="onDeleteGlobalAdditional('${a.id}')">Удл.<\/button>
         <\/div>
       <\/td>
     `;
@@ -1552,7 +1552,7 @@ function onAddGlobalAdditional(){
   renderGlobalAdditionalTable();
 }
 async function onEditGlobalAdditional(id){
-  const x = appData.additionalGlobal.find(a => a.id === id);
+  const x = appData.additionalGlobal.find(a => String(a.id) === String(id));
   if(!x) return;
   const vals = await showMultiPrompt('Расход',[
     {id:'desc',label:'Описание',value:x.description},
@@ -1572,7 +1572,7 @@ async function onEditGlobalAdditional(id){
 }
 function onDeleteGlobalAdditional(id){
   if(!confirm("Удалить статью?")) return;
-  appData.additionalGlobal = appData.additionalGlobal.filter(a => a.id !== id);
+  appData.additionalGlobal = appData.additionalGlobal.filter(a => String(a.id) !== String(id));
   saveToLocalStorage();
   renderGlobalAdditionalTable();
 }
@@ -1730,7 +1730,7 @@ function addModelRow(printerId, modelData) {
   tbody.appendChild(tr);
 }
 function getAllMaterialsForPrinter(printerId, includeAll=false){
-  const pr = appData.printers.find(p => p.id === printerId);
+  const pr = appData.printers.find(p => String(p.id) === String(printerId));
   if(!pr) return [];
   const globalMats = appData.materials.filter(m => {
     if(!includeAll && m.balance <= 0) return false;
@@ -1841,7 +1841,7 @@ function onCalculateAll() {
       
       prTime += h;
       
-      const mat = getAllMaterialsForPrinter(pr.id).find(x => x.id === mid);
+      const mat = getAllMaterialsForPrinter(pr.id).find(x => String(x.id) === String(mid));
       if (!mat) return;
       
       const costPH = (pr.hoursToRecoup > 0) ? pr.cost / pr.hoursToRecoup : 0;
@@ -2159,10 +2159,10 @@ if ((d.linesDetail.length === 0 || !d.linesDetail) && d.printerTime <= 0) {
 }
 
 function findMaterialById(mid) {
-  let mat = appData.materials.find(m => m.id == mid);
+  let mat = appData.materials.find(m => String(m.id) === String(mid));
   if (mat) return mat;
   for (let p of appData.printers) {
-    mat = p.materials.find(m => m.id == mid);
+    mat = p.materials.find(m => String(m.id) === String(mid));
     if (mat) return mat;
   }
   return null;
@@ -2440,11 +2440,11 @@ function downloadThermoLabelHtml(modelName, printerName, materialName, hours, we
 /* Новая функция для генерации этикетки материала в формате 30x20 мм */
 function downloadMaterialLabelHtml(materialId) {
   // Ищем материал сначала в глобальных, затем в материалах принтеров
-  let mat = appData.materials.find(m => m.id === materialId);
+  let mat = appData.materials.find(m => String(m.id) === String(materialId));
   if(!mat) {
     // Если не найден в глобальных, проверяем у каждого принтера
     for(let p of appData.printers) {
-      mat = p.materials.find(m => m.id === materialId);
+      mat = p.materials.find(m => String(m.id) === String(materialId));
       if(mat) break;
     }
   }
@@ -2693,7 +2693,7 @@ function ensureOrcaPrinterFields(){
 }
 
 function openPrinterOrca(id){
-  const pr=appData.printers.find(p=>p.id===id);
+  const pr=appData.printers.find(p=>String(p.id)===String(id));
   if(!pr) return;
   currentOrcaPrinterId=id;
   ensureOrcaPrinterFields();


### PR DESCRIPTION
## Summary
- handle printer IDs as strings when showing details, editing printers, and copying
- ensure material lookups compare stringified IDs
- quote ID usages in buttons so string IDs work

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850f4d7cf188330b417c7a80748fcdb