### PR TITLE
Add model tracking code and thumbnail support

### DIFF
--- a/open_calc.py
+++ b/open_calc.py
@@ -3,12 +3,26 @@ import os
 import re
 import urllib.parse
 import webbrowser
+import uuid
 
 if len(sys.argv) < 2:
     print(f"Usage: {os.path.basename(sys.argv[0])} <gcode_file>")
     sys.exit(1)
 
 file_path = sys.argv[1]
+
+# Read file and ensure unique model code at the very top
+with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+    lines = f.readlines()
+
+model_code = None
+if lines and lines[0].startswith('; MODEL_CODE='):
+    model_code = lines[0].split('=', 1)[1].strip()
+else:
+    model_code = uuid.uuid4().hex
+    lines.insert(0, f'; MODEL_CODE={model_code}\n')
+    with open(file_path, 'w', encoding='utf-8') as fw:
+        fw.writelines(lines)
 
 printer = "Unknown"
 print_time = ""
@@ -18,45 +32,60 @@ filament_settings = ""
 
 after_exec = False
 in_config = False
+thumbnail_data = ""
+in_thumbnail = False
 
-with open(file_path, 'r', encoding='utf-8', errors='ignore') as fh:
-    for line in fh:
-        line = line.strip()
-        if line == '; EXECUTABLE_BLOCK_END':
-            after_exec = True
-            continue
-        if not after_exec:
-            continue
-        if line == '; CONFIG_BLOCK_START':
-            in_config = True
-            continue
-        if line == '; CONFIG_BLOCK_END':
-            in_config = False
-            continue
-        if line.startswith('; estimated printing time') and '=' in line:
-            m = re.search(r'=\s*(.+)$', line)
-            if m:
-                print_time = m.group(1).strip()
-        elif line.startswith('; total filament used [g]') and '=' in line:
-            m = re.search(r'=\s*([0-9.]+)', line)
-            if m:
-                filament_weight = m.group(1)
-        elif in_config:
-            if 'printer_settings_id' in line and '=' in line:
-                m = re.search(r'=\s*"?([^";]+)', line)
-                if m:
-                    printer = m.group(1).strip()
-            elif line.startswith('; filament_type') and '=' in line:
-                m = re.search(r'=\s*"?([^";]+)', line)
-                if m:
-                    filament_type = m.group(1).strip()
-            elif 'filament_settings_id' in line and '=' in line:
-                m = re.search(r'=\s*"?([^";]+)', line)
-                if m:
-                    filament_settings = m.group(1).strip()
+for line in lines:
+    line = line.strip()
+    if line.startswith('; THUMBNAIL_BLOCK_START'):
+        continue
+    if line.startswith('; thumbnail begin'):
+        in_thumbnail = True
+        continue
+    if line.startswith('; thumbnail end'):
+        in_thumbnail = False
+        continue
+    if in_thumbnail:
+        if line.startswith(';'):
+            thumbnail_data += line[1:].strip()
+        else:
+            thumbnail_data += line.strip()
+        continue
 
-model_name = os.path.basename(file_path)
-model_name = re.sub(r'\.gcode(\.pp)?$', '', model_name, flags=re.IGNORECASE)
+    if line == '; EXECUTABLE_BLOCK_END':
+        after_exec = True
+        continue
+    if not after_exec:
+        continue
+    if line == '; CONFIG_BLOCK_START':
+        in_config = True
+        continue
+    if line == '; CONFIG_BLOCK_END':
+        in_config = False
+        continue
+    if line.startswith('; estimated printing time') and '=' in line:
+        m = re.search(r'=\s*(.+)$', line)
+        if m:
+            print_time = m.group(1).strip()
+    elif line.startswith('; total filament used [g]') and '=' in line:
+        m = re.search(r'=\s*([0-9.]+)', line)
+        if m:
+            filament_weight = m.group(1)
+    elif in_config:
+        if 'printer_settings_id' in line and '=' in line:
+            m = re.search(r'=\s*"?([^";]+)', line)
+            if m:
+                printer = m.group(1).strip()
+        elif line.startswith('; filament_type') and '=' in line:
+            m = re.search(r'=\s*"?([^";]+)', line)
+            if m:
+                filament_type = m.group(1).strip()
+        elif 'filament_settings_id' in line and '=' in line:
+            m = re.search(r'=\s*"?([^";]+)', line)
+            if m:
+                filament_settings = m.group(1).strip()
+
+model_name = model_code  # use unique code as name
 
 final_filament = f"{filament_settings}".strip('_')
 
@@ -64,10 +93,14 @@ params = {
     'printer': printer,
     'model_status[]': 'new',
     'model_name[]': model_name,
+    'model_id[]': model_code,
     'model_time[]': print_time,
     'model_weight[]': filament_weight,
     'model_filament[]': final_filament,
 }
+
+if thumbnail_data:
+    params['model_thumbnail[]'] = thumbnail_data
 
 url = 'https://nazbav.github.io/3d-price/test.html?' + urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
 print('Opening:', url)

--- a/test.html
+++ b/test.html
@@ -1666,7 +1666,9 @@ function renderCalcPrinters(){
       <table class="table table-bordered table-sm mb-2" id="calcModelsTable_${pr.id}">
         <thead>
           <tr>
+            <th>Код<\/th>
             <th>Имя модели<\/th>
+            <th>Иконка<\/th>
             <th>Статус<\/th>
             <th>Часы печати<\/th>
             <th>Вес (г)<\/th>
@@ -1705,10 +1707,14 @@ function addModelRow(printerId, modelData) {
   const hoursId = `modelHours_${printerId}_${uniqueId}`;
   const weightId = `modelWeight_${printerId}_${uniqueId}`;
   const materialId = `modelMaterial_${printerId}_${uniqueId}`;
-  const tr = document.createElement("tr");
-  tr.dataset.modelId = modelData.id || uniqueId;
+  const tr = document.createElement('tr');
+  const code = modelData.id || uniqueId;
+  tr.dataset.modelId = code;
+  tr.dataset.thumbnail = modelData.thumbnail || '';
   tr.innerHTML = `
+    <td>${code}<\/td>
     <td><input type="text" class="form-control form-control-sm" id="${nameId}" placeholder="Название" value="${modelData.name || ''}" /><\/td>
+    <td>${modelData.thumbnail ? `<img src="data:image/png;base64,${modelData.thumbnail}" style="height:40px;"/>` : ''}<\/td>
     <td>
       <select class="form-select form-select-sm" id="${statusId}">
         ${optsStatus}
@@ -1861,6 +1867,8 @@ function onCalculateAll() {
       prCostNoTax += subTotalModel;
       
       lines.push({
+        id: row.dataset.modelId || generateUUID(),
+        thumbnail: row.dataset.thumbnail || '',
         name: inpName.value.trim() || "Модель",
         status: selStatus.value || "new",
         hours: h,
@@ -2015,7 +2023,9 @@ if ((d.linesDetail.length === 0 || !d.linesDetail) && d.printerTime <= 0) {
     if (d.linesDetail.length > 0) {
       htmlRes += `<div class="table-responsive"><table class="table table-sm table-bordered mt-1" style="max-width:800px;">`;
       htmlRes += `<thead><tr>
+        <th>Код<\/th>
         <th>Модель<\/th>
+        <th>Иконка<\/th>
         <th>Статус<\/th>
         <th>Часы<\/th>
         <th>Вес (г)<\/th>
@@ -2030,7 +2040,9 @@ if ((d.linesDetail.length === 0 || !d.linesDetail) && d.printerTime <= 0) {
       <\/tr><\/thead><tbody>`;
       d.linesDetail.forEach(ln => {
         htmlRes += `<tr>
+          <td>${ln.id || ''}<\/td>
           <td>${ln.name}<\/td>
+          <td>${ln.thumbnail ? `<img src="data:image/png;base64,${ln.thumbnail}" style="height:40px;"/>` : ''}<\/td>
           <td>${ln.status}<\/td>
           <td>${formatTimeForDisplay(ln.hours)}<\/td>
           <td>${ln.weight.toFixed(2)}<\/td>
@@ -2807,7 +2819,9 @@ function generateMaxDetailedCalcHtml(d) {
     if(pr.linesDetail && pr.linesDetail.length>0){
       s += `<table style="margin-top:5px;">
         <thead><tr>
+          <th>Код<\/th>
           <th>Модель<\/th>
+          <th>Иконка<\/th>
           <th>Статус<\/th>
           <th>Часы<\/th>
           <th>Вес (г)<\/th>
@@ -2818,7 +2832,9 @@ function generateMaxDetailedCalcHtml(d) {
         <tbody>`;
       pr.linesDetail.forEach(ln => {
         s += `<tr>
+          <td>${ln.id || ''}<\/td>
           <td>${ln.name}<\/td>
+          <td>${ln.thumbnail ? `<img src="data:image/png;base64,${ln.thumbnail}" style="height:40px;"/>` : ''}<\/td>
           <td>${ln.status}<\/td>
           <td>${ln.hours.toFixed(2)}<\/td>
           <td>${ln.weight.toFixed(2)}<\/td>
@@ -3374,17 +3390,21 @@ function parseIncomingLinkParams(params){
   if(!prName) return;
   const statuses = params.getAll('model_status[]');
   const names = params.getAll('model_name[]');
+  const ids = params.getAll('model_id[]');
+  const thumbs = params.getAll('model_thumbnail[]');
   const times = params.getAll('model_time[]');
   const weights = params.getAll('model_weight[]');
   const mats = params.getAll('model_filament[]');
   const models = [];
   for(let i=0;i<names.length;i++){
     models.push({
-      name:names[i]||'' ,
-      status:statuses[i]||'new',
-      timeStr:times[i]||'',
-      weight:weights[i]||'',
-      matName:mats[i]||''
+      id: ids[i] || generateUUID(),
+      name: names[i] || '',
+      thumbnail: thumbs[i] || '',
+      status: statuses[i] || 'new',
+      timeStr: times[i] || '',
+      weight: weights[i] || '',
+      matName: mats[i] || ''
     });
   }
   incomingLinkData = {printerName: prName, models};
@@ -3430,7 +3450,9 @@ function applyIncomingData(){
       incomingLinkData.models.forEach(m=>{
         const mat = findMaterialByName(m.matName);
         addModelRow(pr.id, {
+          id: m.id,
           name: m.name,
+          thumbnail: m.thumbnail,
           status: m.status,
           hours: parseTimeFromLink(m.timeStr),
           weight: parseFloat(m.weight)||0,


### PR DESCRIPTION
## Summary
- generate model tracking ID and store at top of gcode
- pass model ID and thumbnail to calculator
- display model code and icon in calculator UI

## Testing
- `python3 -m py_compile open_calc.py`

------
https://chatgpt.com/codex/tasks/task_e_6850fd8181308330a72e21e7e0fea5e0