### PR TITLE
Add runtime function instrumentation

### DIFF
--- a/test.html
+++ b/test.html
@@ -630,6 +630,30 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+const _instrumentInitialKeys = new Set(Object.keys(window));
+
+function instrumentFunctions(){
+  const newKeys = Object.keys(window).filter(k=>!_instrumentInitialKeys.has(k) && typeof window[k]==='function');
+  newKeys.forEach(fnName=>{
+    const original = window[fnName];
+    window[fnName] = function(...args){
+      console.log('▶', fnName, 'called with', args);
+      try{
+        const result = original.apply(this,args);
+        if(result instanceof Promise){
+          return result.then(r=>{console.log('✔', fnName, 'resolved with', r); return r;})
+                       .catch(err=>{console.error('✖', fnName, 'rejected with', err); throw err;});
+        }
+        console.log('✔', fnName, 'returned', result);
+        return result;
+      }catch(e){
+        console.error('✖', fnName, 'threw', e);
+        throw e;
+      }
+    };
+  });
+  console.log('Instrumented functions:', newKeys);
+}
 const THEME_STORAGE_KEY = "themePreference";
 function setTheme(theme) {
   document.documentElement.setAttribute("data-bs-theme", theme);
@@ -916,7 +940,7 @@ function parseTimeFromLink(str){
   return parseTimeInput(str);
 }
 
-document.addEventListener("DOMContentLoaded", initAll);
+document.addEventListener("DOMContentLoaded", () => { instrumentFunctions(); initAll(); });
 
 /* Функции массовых действий */
 function selectAll(source, type) {


### PR DESCRIPTION
## Summary
- add global `instrumentFunctions` utility that wraps all user-defined functions
- trigger instrumentation in the first DOMContentLoaded handler before running `initAll`

## Testing
- `python -m py_compile sync_orca.py open_calc.py`

------
https://chatgpt.com/codex/tasks/task_e_685108036050833095855b0d12c360d1