### PR TITLE
Fix summary period filters in test report

### DIFF
--- a/test.html
+++ b/test.html
@@ -4284,7 +4284,10 @@ function onEditCalcHistory(timestamp){
     const showCustom = val === 'custom';
     fromInput.classList.toggle('d-none', !showCustom);
     toInput.classList.toggle('d-none', !showCustom);
-    applyBtn.classList.remove('d-none');
+    applyBtn.classList.toggle('d-none', !showCustom);
+    if(!showCustom){
+      renderSummary();
+    }
   }
 
   function renderSummary() {
@@ -4304,19 +4307,21 @@ function onEditCalcHistory(timestamp){
     }).format(value);
 
   const period = document.getElementById('summaryPeriod').value;
-  let from = new Date('1970-01-01');
   let to = new Date();
+  let from = new Date(to);
   if(period === 'week'){
-    from.setDate(to.getDate() - 7);
+    from.setDate(from.getDate() - 7);
   } else if(period === 'month'){
-    from.setMonth(to.getMonth() - 1);
+    from.setMonth(from.getMonth() - 1);
   } else if(period === 'year'){
-    from.setFullYear(to.getFullYear() - 1);
+    from.setFullYear(from.getFullYear() - 1);
   } else if(period === 'custom'){
     const fv = document.getElementById('summaryFrom').value;
     const tv = document.getElementById('summaryTo').value;
     if(fv) from = new Date(fv);
     if(tv){ to = new Date(tv); to.setDate(to.getDate()+1); }
+  } else if(period === 'all'){
+    from = new Date('1970-01-01');
   }
 
   // 1. Расчет капитальных вложений


### PR DESCRIPTION
## Summary
- Fix week/month/year filters in test.html summary view
- Auto-refresh summary when non-custom period selected

## Testing
- `npx -y htmlhint test.html` *(fails: Duplicate attribute, tag mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_689ba149727483309473cf60059a7cca